### PR TITLE
Suppress libtool warning for no symbols

### DIFF
--- a/VectorBrush.xcodeproj/project.pbxproj
+++ b/VectorBrush.xcodeproj/project.pbxproj
@@ -561,6 +561,7 @@
 				INSTALL_PATH = "";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LIBTOOLFLAGS = "-no_warning_for_no_symbols";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(PRODUCT_NAME)";
 				SKIP_INSTALL = NO;
@@ -596,6 +597,7 @@
 				INSTALL_PATH = "";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LIBTOOLFLAGS = "-no_warning_for_no_symbols";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(PRODUCT_NAME)";
 				SKIP_INSTALL = NO;

--- a/VectorBrush/NSBezierPath+FitCurve.m
+++ b/VectorBrush/NSBezierPath+FitCurve.m
@@ -11,11 +11,6 @@
 #import "Geometry.h"
 #import "math.h"
 
-void FBSuppressLinkWarning(void) {
-    // TODO #6510 - find a better way to do this...
-    NSLog(@"this is a dummy method which is here to suppress a linker warning, caused by the fact that the library only contained category methods and had no actual public functions");
-}
-
 // Algorithm implemented here is the one described in "An Algorithm for Automatically Fitting Digitized Curves"
 //  by Philip J. Schneider contained in the book Graphics Gems
 


### PR DESCRIPTION
Because the static library only contains categories libtool thinks its empty.